### PR TITLE
Updated Frontend

### DIFF
--- a/client/a4_export.html
+++ b/client/a4_export.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<!-- KaTeX requires the use of the HTML5 doctype. Without it, KaTeX may not render properly -->
+<html>
+    <head>
+        <meta charset="utf-8"/>
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.18/dist/katex.css" integrity="sha384-ysFyB7Is//Q1JNgERb0bLJokXKM8eWJsjEutGvthoHtBilHWgbdmbYkQZdwCIGIq" crossorigin="anonymous">
+        <script src="https://cdn.jsdelivr.net/npm/katex@0.13.18/dist/katex.js" integrity="sha384-UWjC+k927Mtx6WQF5SzKTXLLrOYmzs69HvkUjiKvUwSOljzc+C6PrGquNpOvJBBo" crossorigin="anonymous"></script>
+        <link href="style.css" rel="stylesheet">
+        <script src="scripts.js"></script>
+        <title>A4 Export</title>
+    
+        <style>
+            * { color: black; }
+    
+            html { background-color: rgb(148, 127, 114); }
+
+            body {
+                width:210mm;
+                margin: 0;
+            }
+
+            #widthWrap {
+                background-color: white;
+            }
+
+            #outputBox {
+                width: 100%;
+                margin: 0;
+                padding-top: 1em;
+            }
+
+            @media print {
+                html {
+                    background-color: white;
+                }
+            }
+        </style>
+    </head>
+    <body>
+        <div id="widthWrap">
+            <p id="outputBox"></p>
+        </div>
+
+        <script>
+            var outputBox = document.getElementById("outputBox");
+            var noteName = getNoteName();
+            var text = "";
+
+            if (noteName) { // try load from server
+                let serverNote = getNoteFromServer(noteName);
+
+                if (serverNote) { // got a note
+                    text = serverNote;
+                    document.title = "Loaded from server";
+                    setInterval(refreshNote, 5000);
+                }
+                else { // failed to get note
+                    text = sessionStorage.getItem('katexAutosave') || "\\text{Tried to load note '" + noteName + "'}\\\\\\text{Failed to load from server, no local save}";
+                    document.title = "Failed to load from server";
+                }
+            }
+            else { // no note requested
+                text = sessionStorage.getItem('katexAutosave') || "\\text{Finished Loading!} \\\\\\text{No notes requested}";
+                document.title = "No note requested";
+            }
+
+            tryRenderOutput(text, outputBox);
+
+            var lastLoadFinished = true;
+            function refreshNote() {
+                if (!lastLoadFinished) return;
+
+                document.title = "Loading...";
+                var serverNote = getNoteFromServer(noteName);
+                
+                if (serverNote) {
+                    text = serverNote;
+                    document.title = "Loaded from server";
+                    tryRenderOutput(text, outputBox);
+                }
+
+                lastLoadFinished = true;
+            }
+        </script>
+    </body>
+</html>

--- a/client/index.html
+++ b/client/index.html
@@ -12,7 +12,8 @@
     <body>
         <p id="statusBox">STATUS: Loading!</p>
         <button onclick="let n = prompt('Enter note name'); location.href= n ? '?note='+n : '?';" type="button">open</button>
-        <button onclick="location.href='viewer?note='+noteName;" type="button">export</button>
+        <button onclick="location.href='viewer?note='+noteName;" type="button">viewer</button>
+        <button onclick="location.href='a4_export?note='+noteName;" type="button">print</button>
         <button onclick="toggleEditorSize();" type="button">toggle preview</button>
         <button onclick="location.href='?macros';" type="button">macros</button>
         <button onclick="location.href='?notes_list';" type="button">notes list</button>

--- a/client/scripts.js
+++ b/client/scripts.js
@@ -110,8 +110,7 @@ function renderOI(inputBox, inputHighlightBox, outputBox, inputWrapper) {
 
 function tryRenderOutput(text, outputBox) { // returns whether success or not
     try {
-        var html = katex.renderToString(text, {displayMode: true, trust: true});
-        outputBox.innerHTML = html;
+        outputBox.innerHTML = katex.renderToString(text, {displayMode: true, trust: true});
         outputBox.style.backgroundColor = '';
 
         return true;
@@ -119,11 +118,12 @@ function tryRenderOutput(text, outputBox) { // returns whether success or not
     catch (e) {
         if (e instanceof katex.ParseError) {
             // KaTeX can't parse the expression
-            var errorString = ("Error in LaTeX '" + text + "': " + e.message)
-                .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-            
-            console.log(errorString);
-            outputBox.style.backgroundColor = '#800000';
+            // var errorString = ("Error in LaTeX '" + text + "': " + e.message)
+            //     .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+            // console.log(errorString);
+
+            outputBox.style.backgroundColor = '#300000';
+            outputBox.innerHTML = katex.renderToString(text, {displayMode: true, trust: true, throwOnError: false});
 
             return false;
         } else {

--- a/client/scripts.js
+++ b/client/scripts.js
@@ -167,6 +167,38 @@ function colorInnerHTML(text) {
 
             position += 1 + insertTextP1.length + 1 + insertTextP2.length;
         }
+        else if (startPos === undefined && curChar === '\\' && newText.length > position + 'color{}'.length && newText.substring(position, position+7) === '\\color{') { // case of \color{<color name>}
+            // highlight the \color part
+            let insertText1 = '<span style="color:#70d14d">';
+            let insertText2 = '</span>';
+            newText = newText.slice(0, position) + insertText1 + '\\color' + insertText2 + newText.slice(position+6);
+            position += insertText1.length + insertText2.length + '\\color'.length;
+
+            position++; // skip the {
+
+            // highlight the <color name> in its own colour
+            let i = position;
+            let buffer = '';
+            while (true) {
+                let c = newText[i];
+
+                if ((startHighlight.includes(c) || endHighlight.includes(c) || slashHighlightOrange.includes(c))
+                 && c !== '}' && !(c === '#' && i === position && newText[position+7] === '}' || i === position && newText[position+4] === '}')) break; // special characters, except } and when color is hash code
+                else if (c === '}') { // end of colour text, highlight
+                    let insertText3 = '<span style="color:'+buffer+'">';
+                    let insertText4 = '</span>';
+                    newText = newText.slice(0, position) + insertText3 + buffer + insertText4 + newText.slice(position+buffer.length);
+                    position += insertText3.length + insertText4.length + buffer.length;
+                    break;
+                }
+                else if (c) buffer += c;
+                else break; // end of text
+
+                i++;
+            }
+
+            position++; // skip the }
+        }
         else if (startPos === undefined && startHighlight.includes(curChar)) { // regular start
             let insertText = '<span style="color:#70d14d">';
 

--- a/client/style.css
+++ b/client/style.css
@@ -2,6 +2,7 @@
     font-size: 20px;
     color: white;
     caret-color: white;
+    box-sizing: border-box;
 } 
 
 body {

--- a/client/viewer.html
+++ b/client/viewer.html
@@ -7,15 +7,11 @@
         <script src="https://cdn.jsdelivr.net/npm/katex@0.13.18/dist/katex.js" integrity="sha384-UWjC+k927Mtx6WQF5SzKTXLLrOYmzs69HvkUjiKvUwSOljzc+C6PrGquNpOvJBBo" crossorigin="anonymous"></script>
         <link href="style.css" rel="stylesheet">
         <script src="scripts.js"></script>
-        <title>Katex Editor</title>
+        <title>Katex Editor - Viewer</title>
     
         <style>
         #outputBox {
             width: 100%;
-            
-            border-style: solid;
-            border-color: white;
-            border-width: 0.1px; 
         }
         </style>
     </head>


### PR DESCRIPTION
- Highlights \<colour> part of '\color{\<colour>}' as \<colour> in editor
- Renders even when unsupported function used. Shows hovertext when invalid KaTeX. As opposed to just not updating the output at all
- Added A4 Export page which prints nicely (for exporting my assignments)
- Added/changed a4 export and viewer buttons a bit
- Added box-sizing: border-box; to css for all elements by default